### PR TITLE
Run e2e test on Go 1.21

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: 1.21.x
       # - name: Install ko
       #   run: |
       #     GO111MODULE=on go get github.com/google/ko/cmd/ko


### PR DESCRIPTION
The e2e test in the current [update dependencies](https://github.com/knative-extensions/eventing-redis/pull/502) fails, because the `toolchain` directive is added, which is only supported with Go 1.21. This PR addresses it and updates Go to 1.21 for the e2e tests