### PR TITLE
fix: pass application context to adapter setup

### DIFF
--- a/cmd/source/receive_adapter/main.go
+++ b/cmd/source/receive_adapter/main.go
@@ -18,10 +18,14 @@ package main
 
 import (
 	"knative.dev/eventing/pkg/adapter/v2"
+	"knative.dev/pkg/signals"
 
 	kadapter "knative.dev/eventing-redis/pkg/source/adapter"
 )
 
 func main() {
-	adapter.Main("redis-stream-source", kadapter.NewEnvConfig, kadapter.NewAdapter)
+	ctx := signals.NewContext()
+	ctx = adapter.WithInjectorEnabled(ctx)
+
+	adapter.MainWithContext(ctx, "redis-stream-source", kadapter.NewEnvConfig, kadapter.NewAdapter)
 }


### PR DESCRIPTION
This should fix the bug discussed in https://cloud-native.slack.com/archives/C04LMU33V1S/p1715187459359989. This fix is based on https://github.com/knative-extensions/eventing-gitlab/commit/ed31b7181108f83d18545aa4539d342b1da30280

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Pass the app context to the adapter setup


```release-note
fixed bug where receive adapter did not start properly
```
