### PR TITLE
Fixes # Check for Password to Redis on Cloud

### DIFF
--- a/pkg/source/adapter/adapter.go
+++ b/pkg/source/adapter/adapter.go
@@ -237,7 +237,7 @@ func (a *Adapter) newPool(address string) *redis.Pool {
 		// configuring a connection.
 		Dial: func() (redis.Conn, error) {
 			var c redis.Conn
-			if opt.Password != "" && a.config.TLSCertificate != "" {
+			if a.config.TLSCertificate != "" {
 				roots := x509.NewCertPool()
 				ok := roots.AppendCertsFromPEM([]byte(a.config.TLSCertificate))
 				if !ok {


### PR DESCRIPTION
When we connect to Redis on Cloud, we generally do not need password and username. We can just be done with TLS. 

We need to pass a dummy username and password, which is anyways not valid but the service starts as the server reject the password and goes ahead with TLS connection.

```
apiVersion: sources.knative.dev/v1alpha1
kind: RedisStreamSource
metadata:
  name: samplesource
  namespace: user1
spec:
  address: "rediss://default:password@amaaaaaa74akfsaami2pqxkiosy2gsfsv22fszx77pkb5yj2gemfbqj37lwa-p.redis.us-ashburn-1.oci.oraclecloud.com:6379"
  stream: teststream
  sink:
    ref:
      apiVersion: serving.knative.dev/v1
      kind: Service
      name: event-display
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Drop the if condition for mandatory password check in URL.

<!--
If this change has user-visible impact, follow the instructions below.
- 🧽 Update or clean up current behavior
-->
