### PR TITLE
Simple fix for #387: return a panic error

### DIFF
--- a/pkg/source/adapter/adapter.go
+++ b/pkg/source/adapter/adapter.go
@@ -186,6 +186,9 @@ func (a *Adapter) processEntry(ctx context.Context, conn redis.Conn, streamName 
 		if !isShuttingDown {
 			time.Sleep(1 * time.Second)
 		}
+		if strings.Contains(strings.ToLower(err.Error()), "use of closed network connection") {
+			panic(err)
+		}
 		return xreadID
 	}
 


### PR DESCRIPTION
Fixes #387

## Proposed Changes

Panic if error contains "use of closed network connection" (it is a try)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🐛 Fix #387 Exit receive_adapter if in an error "use of closed network connection"
```

