### PR TITLE
Fix #626 panic on invalid tls config in secret

### DIFF
--- a/config/sink/tls-secret.yaml
+++ b/config/sink/tls-secret.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: knative-sinks
 stringData:
   # the data is abbreviated in this example
-  TLS_CERT: |+
-    -----BEGIN CERTIFICATE-----
-    -----END CERTIFICATE-----
+  TLS_CERT: ""

--- a/config/source/tls-secret.yaml
+++ b/config/source/tls-secret.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: knative-sources
 stringData:
   # the data is abbreviated in this example
-  TLS_CERT: |+
-    -----BEGIN CERTIFICATE-----
-    -----END CERTIFICATE-----
+  TLS_CERT: ""

--- a/pkg/sink/reconciler/streamsink/streamsink.go
+++ b/pkg/sink/reconciler/streamsink/streamsink.go
@@ -95,7 +95,8 @@ func (r *Reconciler) updateTLSSecret(ctx context.Context, secret *corev1.Secret)
 	tlsSecret, err := GetTLSSecret(secret.Data)
 	if err != nil {
 		logging.FromContext(ctx).Errorw("Error reading TLS configuration", zap.Error(err))
+	} else {
+		// For now just override the previous config.
+		r.tlsCert = tlsSecret.TLSCertificate
 	}
-	// For now just override the previous config.
-	r.tlsCert = tlsSecret.TLSCertificate
 }

--- a/pkg/source/adapter/adapter.go
+++ b/pkg/source/adapter/adapter.go
@@ -241,7 +241,7 @@ func (a *Adapter) newPool(address string) *redis.Pool {
 				roots := x509.NewCertPool()
 				ok := roots.AppendCertsFromPEM([]byte(a.config.TLSCertificate))
 				if !ok {
-					panic(err)
+					panic("cannot add tls certificate to cert pool")
 				}
 				c, err = redis.Dial("tcp", opt.Addr,
 					redis.DialUsername(opt.Username),

--- a/pkg/source/reconciler/streamsource/streamsource.go
+++ b/pkg/source/reconciler/streamsource/streamsource.go
@@ -127,16 +127,18 @@ func (r *Reconciler) updateRedisConfig(ctx context.Context, configMap *corev1.Co
 	redisConfig, err := GetRedisConfig(configMap.Data)
 	if err != nil {
 		logging.FromContext(ctx).Errorw("Error reading Redis configuration", zap.Error(err))
+	} else {
+		// For now just override the previous config.
+		r.numConsumers = redisConfig.NumConsumers
 	}
-	// For now just override the previous config.
-	r.numConsumers = redisConfig.NumConsumers
 }
 
 func (r *Reconciler) updateTLSSecret(ctx context.Context, secret *corev1.Secret) {
 	tlsSecret, err := GetTLSSecret(secret.Data)
 	if err != nil {
 		logging.FromContext(ctx).Errorw("Error reading TLS configuration", zap.Error(err))
+	} else {
+		// For now just override the previous config.
+		r.tlsCert = tlsSecret.TLSCertificate
 	}
-	// For now just override the previous config.
-	r.tlsCert = tlsSecret.TLSCertificate
 }


### PR DESCRIPTION
Fixes #626 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add a panic message if redis tls config is invalid (in source adapter)
- Fix condition of affecting tls certificate and redis config when they are empty/invalid

**Release Note**

```release-note
🐛 Fix RedisStreamSource when no Redis TLS certificate is given
```

**Docs**
https://github.com/knative-extensions/eventing-redis/issues/626

